### PR TITLE
Allow simple copy-to-clipboard export and add notification for GitHub workflow

### DIFF
--- a/PastelogKit.podspec
+++ b/PastelogKit.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "PastelogKit"
-  s.version      = "1.3"
+  s.version      = "1.4"
   s.summary      = "A simple library that provides an easy fragment allowing users to throw debug logs in a pastebin (currently gist) online."
 
   s.homepage     = "https://github.com/FredericJacobs/PastelogKit"

--- a/src/Pastelog.m
+++ b/src/Pastelog.m
@@ -42,7 +42,7 @@ static const NSUInteger ddLogLevel = DDLogLevelAll;
     [self submitLogsWithCompletion:^(NSError *error, NSString *urlString) {
         if (!error) {
             sharedManager.gistURL = urlString;
-            sharedManager.submitAlertView = [[UIAlertView alloc]initWithTitle:@"Submit Debug Log" message:@"Bugs can be reported by email or by copying the log in a GitHub Issue (advanced)." delegate:[self sharedManager] cancelButtonTitle:@"GitHub Issue" otherButtonTitles:@"Email", nil];
+            sharedManager.submitAlertView = [[UIAlertView alloc]initWithTitle:@"Submit Debug Log" message:@"Bugs can be reported by email or by copying the log in a GitHub Issue (advanced). You can also get the gist link directly in your clipboard." delegate:[self sharedManager] cancelButtonTitle:@"GitHub Issue" otherButtonTitles:@"Email", @"Clipboard", nil];
             [sharedManager.submitAlertView show];
         } else{
             UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:@"Failed to submit debug log" message:@"The debug log could not be submitted. Please try again." delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil, nil];
@@ -180,8 +180,11 @@ static const NSUInteger ddLogLevel = DDLogLevelAll;
     } else if (alertView == self.submitAlertView) {
         if (buttonIndex == 0) {
             [self pasteBoardCopy:self.gistURL];
-        } else{
+        } else if (buttonIndex == 1) {
             [self submitEmail:self.gistURL];
+        } else {
+            UIPasteboard *pb = [UIPasteboard generalPasteboard];
+            [pb setString:self.gistURL];
         }
     }
 }

--- a/src/Pastelog.m
+++ b/src/Pastelog.m
@@ -17,6 +17,7 @@ static const NSUInteger ddLogLevel = DDLogLevelAll;
 @property (nonatomic)UIAlertView *reportAlertView;
 @property (nonatomic)UIAlertView *loadingAlertView;
 @property (nonatomic)UIAlertView *submitAlertView;
+@property (nonatomic)UIAlertView *infoAlertView;
 @property (nonatomic)NSMutableData *responseData;
 @property (nonatomic, copy)successBlock block;
 @property (nonatomic, copy)NSString *gistURL;
@@ -179,13 +180,15 @@ static const NSUInteger ddLogLevel = DDLogLevelAll;
         }
     } else if (alertView == self.submitAlertView) {
         if (buttonIndex == 0) {
-            [self pasteBoardCopy:self.gistURL];
+            [self prepareRedirection:self.gistURL];
         } else if (buttonIndex == 1) {
             [self submitEmail:self.gistURL];
         } else {
             UIPasteboard *pb = [UIPasteboard generalPasteboard];
             [pb setString:self.gistURL];
         }
+    } else if (alertView == self.infoAlertView) {
+        [UIApplication.sharedApplication openURL:[NSURL URLWithString:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"LOGS_URL"]]];
     }
 }
 
@@ -199,10 +202,11 @@ static const NSUInteger ddLogLevel = DDLogLevelAll;
     [UIApplication.sharedApplication openURL: [NSURL URLWithString: urlString]];
 }
 
-- (void)pasteBoardCopy:(NSString*)url {
+- (void)prepareRedirection:(NSString*)url {
     UIPasteboard *pb = [UIPasteboard generalPasteboard];
     [pb setString:url];
-    [UIApplication.sharedApplication openURL:[NSURL URLWithString:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"LOGS_URL"]]];
+    self.infoAlertView = [[UIAlertView alloc]initWithTitle:@"GitHub redirection" message:@"The gist link was copied in your clipboard. You are about to be redirected to the GitHub issue list." delegate:self cancelButtonTitle:@"OK" otherButtonTitles: nil];
+    [self.infoAlertView show];
 }
 
 @end


### PR DESCRIPTION
Push suggestions made by @michaelkirk at https://github.com/WhisperSystems/Signal-iOS/issues/1338 (Submit Debug Log should make it obvious it's copying to clipboard)

I added a third option just for clipboard export and added a notification stating that the link is in the clipboard when using the GitHub export.

![third option](https://cloud.githubusercontent.com/assets/1410356/20888030/648f84d2-bafd-11e6-9f05-fd3c2d317ed7.png)
![notification](https://cloud.githubusercontent.com/assets/1410356/20888060/869f336a-bafd-11e6-9ca3-1223a318a644.png)

Should fix https://github.com/WhisperSystems/Signal-iOS/issues/1338
